### PR TITLE
Logstash style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ node_modules
 
 # Optional REPL history
 .node_repl_history
+
+# Editors
+.zedstate

--- a/README.md
+++ b/README.md
@@ -63,14 +63,14 @@ plugins:
 	/* (Optional) Index settings:
 	* https://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-update-settings.html
 	*/
-	settings: {
+	indexSettings: {
 		number_of_shards: 1
 	}
 
 	/* (Optional) Index mapping:
 	* https://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-put-mapping.html
 	*/
-	mapping: {
+	indexMappings: {
     type1: {
 			properties: {
 				field1: {

--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ plugins:
   storage:
     name: elasticsearch
     options:
-      host: ${ELASTICSEARCH_HOST}
-      database: 'someDb'
-      defaultTable: 'someTable'
+      host: 'localhost:9200'
+      index: 'someIndex'
+      defaultType: 'someType'
       splitChar: '/'
-      settings: '
+      indexSettings: '
         {
-          "number_of_shards": "1"
+          "number_of_shards" : 1
         }
       '
-      mappings: '
+      indexMappings: '
         {
           "type1" : {
             "properties" : {
@@ -40,11 +40,11 @@ plugins:
 
 	//(Optional, defaults to 'deepstream'). This is the index in elasticsearch,
 	//using database for consistency across all plugins.
-	database: 'someDb',
+	index: 'someIndex',
 
 	//(Optional, defaults to 'deepstream_records'). This is the type in elasticsearch,
 	//using table for consistency across all plugins
-	defaultTable: 'someTable',
+	defaultType: 'someType',
 
 	//(Optional, defaults to 1000). This is the ping timeout used
 	//when doing the initial ping to ensure the connection is setup correctly
@@ -60,13 +60,15 @@ plugins:
 	*/
 	splitChar: '/'
 
-	/* (Optional) Index settings: https://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-create-index.html
+	/* (Optional) Index settings:
+	* https://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-update-settings.html
 	*/
 	settings: {
 		number_of_shards: 1
 	}
 
-	/* (Optional) Index mapping: https://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-create-index.html
+	/* (Optional) Index mapping:
+	* https://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-put-mapping.html
 	*/
 	mapping: {
     type1: {
@@ -88,8 +90,7 @@ var Deepstream = require( 'deepstream.io' ),
     server = new Deepstream();
 
 server.set( 'storage', new ElasticSearchStorageConnector( {
-  host: 'localhost:5672',
-  pingTimeout: 200,
+  host: 'localhost:9200',
   splitChar: '/'
 }));
 

--- a/example-config.yml
+++ b/example-config.yml
@@ -2,7 +2,6 @@ plugins:
   storage:
     name: elasticsearch
     options:
-      host: ${ELASTICSEARCH_HOST}
-      database: 'someDb'
-      defaultTable: 'someTable'
+      host: 'localhost:9200'
+      index: 'someIndex'
       splitChar: '/'

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "url": "git+https://github.com/deepstreamIO/deepstream.io-storage-elasticsearch.git"
   },
   "keywords": [
-    "elasticsearch",
-    "deepstream.io"
+    "deepstream.io",
+    "elasticsearch"
   ],
   "author": "deepstreamHub GmbH",
   "license": "Apache-2.0",
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/deepstreamIO/deepstream.io-storage-elasticsearch#readme",
   "dependencies": {
-    "elasticsearch": "^11.0.1"
+    "elasticsearch": "^12.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/deepstreamIO/deepstream.io-storage-elasticsearch#readme",
   "dependencies": {
-    "elasticsearch": "^12.1"
+    "elasticsearch": "^13.0.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/src/connection.js
+++ b/src/connection.js
@@ -14,8 +14,8 @@ var Connection = function( options, callback ) {
   this._connection = null
 
   this._pingTimeout = options.pingTimeout || 1000
-  this._index = options.database || 'deepstream'
-  this._defaultType = options.defaultType || 'deepstream_records'
+  this._index = options.index || 'deepstream'
+  this._defaultType = options.defaultType || 'deepstream_record'
   this._splitChar = options.splitChar || null
   this._indexSettings = options.indexSettings || '{}'
   this._indexMappings = options.indexMappings || '{}'

--- a/src/connection.js
+++ b/src/connection.js
@@ -148,7 +148,7 @@ Connection.prototype._checkConnection = function() {
  */
 Connection.prototype._createIndexTemplate = function() {
   var template = {
-        aliases: this._index,
+        aliases: JSON.parse(`{"${this._index}":{}}`),
         template: this._index + '-*',
         settings: JSON.parse(this._indexSettings),
         mappings: JSON.parse(this._indexMappings)

--- a/src/connection.js
+++ b/src/connection.js
@@ -150,8 +150,8 @@ Connection.prototype._createIndexTemplate = function() {
   var template = {
         aliases: JSON.parse(`{"${this._index}":{}}`),
         template: this._index + '-*',
-        settings: JSON.parse(this._indexSettings),
-        mappings: JSON.parse(this._indexMappings)
+        settings: (typeof(this._indexSettings) == 'string' ? JSON.parse(this._indexSettings) : this._indexSettings),
+        mappings: (typeof(this._indexMappings) == 'string' ? JSON.parse(this._indexMappings) : this._indexMappings)
       };
 
   this.client.indices.putTemplate( {


### PR DESCRIPTION
 ### Changes

* Updated the README and example config file. The examples were still those from the RethinkDB storage examples, it seems.
* Instead of creating the index on start, create an index template. This will allow the use of LogStash style indexes. Explained in detail below.

### LogStash Style

For greater scale when using Elasticsearch, not having everything in one index is very useful. 

Taking this config...

```
plugins:
  storage:
    name: elasticsearch
    options:
      host: ‘localhost:9200’
      database: ‘tweets’
      splitChar: '/'
```

... instead of creating an index name `tweets`, the record will be saved in an index suffixed by the date and an alias to the set index created. So with the config above the index name, for today, will be `tweets-2016-12-07` and the index will have an alias `tweets`.

Everyday a new index will be automatically created.

Elasticsearch will transparetnly get and delete records over all indexes using the alias. The index itself is only referenced when setting.

Mappings and settings now will be applied to all new indexes created matching the template pattern. If the mapping needs to be changed, this will allow the new index to have updated mappings and, if the setup only keeps a rolling 7 days of indexes, the old mappings to be depreated within 7 days rather than migrating the index.

A config using tweets as an example: Here the default for all fields is to not be analyzed and the only field that is analyzed is the GEO information.


```
plugins:
  storage:
    name: elasticsearch
    options:
      host: ‘localhost:9200’
      index: ‘tweets’
      splitChar: '/'
      indexMappings: '
        "_default_": {
	      "dynamic_templates": [
	        {
	          "not_analyzed": {
	            "match": "*",
	            "match_mapping_type": "string",
	            "mapping": {
	              "type": "string",
	              "index": "not_analyzed"
	            }
	          }
	        }
	      ]
        },
        "tweet": {
          "properties": {
            "place": {
              "properties": {
                "bounding_box": {
                  "coerce": true,
                  "type": "geo_shape"
                }
              }
            }
          }
        }
      '
```

Settings can be set the same way, as the config below for a simple one node setup...


```
plugins:
  storage:
    name: elasticsearch
    options:
      host: ‘localhost:9200’
      index: ‘tweets’
      splitChar: '/'
      indexSettings: '
        {
          "number_of_shards": 1,
          "number_of_replicas": 0
        }
	  '
```