### PR TITLE
Allow to use hosts option

### DIFF
--- a/src/connector.js
+++ b/src/connector.js
@@ -123,8 +123,8 @@ Connector.prototype._onConnection = function( error ) {
  * @returns {void}
  */
 Connector.prototype._checkOptions = function( options ) {
-  if( typeof options.host !== 'string' ) {
-    throw new Error( 'Missing option host' )
+  if( options.hosts === undefined && typeof options.host !== 'string' ) {
+    throw new Error( 'Missing option host or hosts' )
   }
 }
 


### PR DESCRIPTION
elasticsearch-js can connect multiple nodes by using `hosts` option.